### PR TITLE
feat: added ci checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,56 @@ on:
     branches: [ main, master ]
 
 jobs:
-  test:
+  # Separate job for code formatting checks
+  format-check:
+    name: Code Formatting
     runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Check code formatting
+      run: npm run format:check
+
+  # Separate job for linting checks
+  lint-check:
+    name: Code Linting
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Generate Prisma Client
+      run: npx prisma generate
+    
+    - name: Run linting
+      run: npm run lint
+
+  # Main test job that depends on formatting and linting
+  test:
+    name: Tests and Build
+    runs-on: ubuntu-latest
+    needs: [format-check, lint-check]  # Only run if formatting and linting pass
     
     strategy:
       matrix:
@@ -29,12 +77,6 @@ jobs:
     
     - name: Generate Prisma Client
       run: npx prisma generate
-    
-    - name: Check code formatting
-      run: npm run format:check
-    
-    - name: Run linting
-      run: npm run lint
     
     - name: Validate test coverage for new code
       run: |


### PR DESCRIPTION
This pull request refactors the CI workflow configuration in `.github/workflows/ci.yml` to improve modularity and ensure code quality. It introduces separate jobs for code formatting and linting checks, which must pass before the main test job is executed.

### CI Workflow Improvements:

* **Added separate job for code formatting checks**: Introduced a `format-check` job to independently verify code formatting using `npm run format:check`. This job includes steps for checking out the code, setting up Node.js, installing dependencies, and running the formatting check.

* **Added separate job for linting checks**: Created a `lint-check` job to run linting checks using `npm run lint`. This job also generates the Prisma Client before linting to ensure proper setup.

* **Updated test job dependencies**: Modified the `test` job to depend on the successful completion of both the `format-check` and `lint-check` jobs, ensuring that tests and builds are only executed if the code passes formatting and linting checks.

### Code Cleanup:

* **Removed redundant steps from the test job**: Removed inline formatting and linting checks from the `test` job, as these are now handled by their respective dedicated jobs.